### PR TITLE
getKeyFromDoc does not support dot notation

### DIFF
--- a/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
+++ b/packages/node_modules/pouchdb-find/src/adapters/local/utils.js
@@ -47,7 +47,9 @@ function getKeyFromDoc(doc, index) {
   var res = [];
   for (var i = 0; i < index.def.fields.length; i++) {
     var field = getKey(index.def.fields[i]);
-    res.push(doc[field]);
+    var parsedField = parseField(field);
+    var docFieldValue = getFieldFromDoc(doc, parsedField);
+    res.push(docFieldValue);
   }
   return res;
 }


### PR DESCRIPTION
The [CouchDB API](http://docs.couchdb.org/en/2.1.2/api/database/find.html#subfields) supports filtering on sub fields by using hierarchical selectors or by providing the field names in dot notation. Currently fields in dot notation are silently ignored because their values are not extracted from the document. The root cause is the `getKeyFromDoc` function that expects all fields in the index to be "flat" (i.e. top-level fields).